### PR TITLE
add branch only job.

### DIFF
--- a/.github/workflows/verify-branch-only-job.yml
+++ b/.github/workflows/verify-branch-only-job.yml
@@ -1,0 +1,10 @@
+name: "hosted runner"
+on:
+  workflow_dispatch:
+
+jobs:
+  echo:
+    runs-on: ubuntu-latest
+    steps:
+      - name: execute echo command
+        run: echo "hello world"


### PR DESCRIPTION
新しくGithub actionsにジョブを追加した際にmasterマージしなくても実行できるかを確認するためのbranch
なので、masterマージはしないままにしておく